### PR TITLE
remove hardcoded DN from create_security_group method

### DIFF
--- a/lib/active_directory/group.rb
+++ b/lib/active_directory/group.rb
@@ -66,7 +66,7 @@ module ActiveDirectory
       attributes = {
         :objectClass => ['top', 'group'],
         :sAMAccountName => name,
-        :objectCategory => "CN=Group,CN=Schema,CN=Configuration,DC=afssa,DC=fr",
+        :objectCategory => "CN=Group,CN=Schema,CN=Configuration,#{@@settings[:base]}",
         :groupType => type_mask.to_s
       }
       @@ldap.add(:dn => dn, :attributes => attributes)


### PR DESCRIPTION
This attribute appears to be unique to each AD; without this update,
security groups cannot be created
