### PR TITLE
ability to select what attributes to return in Base find methods

### DIFF
--- a/active_directory.gemspec
+++ b/active_directory.gemspec
@@ -1,4 +1,5 @@
 require File.expand_path("../lib/active_directory/version", __FILE__)
+require 'date'
 
 Gem::Specification.new do |s|
   s.name = "active_directory"

--- a/lib/active_directory/base.rb
+++ b/lib/active_directory/base.rb
@@ -264,9 +264,11 @@ module ActiveDirectory
 
 			options = {
 				:filter => (args[1].nil?) ? NIL_FILTER : args[1],
-				:in => (args[1].nil?) ? '' : ( args[1][:in] || '' )
+				:in => (args[1].nil?) ? '' : ( args[1][:in] || '' ),
+				:attributes => (args[1].nil?) ? [] : (args[1][:attributes] || [])
 			}
 			options[:filter].delete(:in)
+			options[:filter].delete(:attributes)
 
 			cached_results = find_cached_results(args[1])
 			return cached_results if cached_results or cached_results.nil?

--- a/lib/active_directory/base.rb
+++ b/lib/active_directory/base.rb
@@ -323,7 +323,7 @@ module ActiveDirectory
 
 		def self.find_all(options)
 			results = []
-			ldap_objs = @@ldap.search(:filter => options[:filter], :base => options[:in]) || []
+			ldap_objs = @@ldap.search(:filter => options[:filter], :base => options[:in], :attributes => options[:attributes]) || []
 
 			ldap_objs.each do |entry|
 				ad_obj = new(entry)
@@ -335,7 +335,7 @@ module ActiveDirectory
 		end
 
 		def self.find_first(options)
-      ldap_result = @@ldap.search(:filter => options[:filter], :base => options[:in])
+      ldap_result = @@ldap.search(:filter => options[:filter], :base => options[:in], :attributes => options[:attributes])
       return nil if ldap_result.empty?
 
 			ad_obj = new(ldap_result[0])


### PR DESCRIPTION
I am populating select fields in html forms with users from active directory. The problem is that all I need is the dn, username and/or cn while the search method was returning all the attributes including group names and thumbnail data etc. 

I changed the find methods to allow for the passing of an array of attributes for this purpose. The only portion that I think this might adversely effect is caching possibly with cases where caching occurs for a query with selected attributes and then you run a query for all attributes and it returns a cache with those missing but I haven't looked to much at that code. Let me know if it does and I'll make the required changes to caching to accommodate that. 

Otherwise, if you want to pull, I can add the changes to the documentation.

Thanks, and great work with this by the way!